### PR TITLE
Add a base href for cleaner routing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
+    <base href="/" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
issue is that when there were characters appended to routes the browser was trying to load in our index.html page instead of image and style assests. Solution here is to add a base href (got it from this stackoverflow comment: https://stackoverflow.com/questions/29718481/unexpected-token-error-in-react-router-component)

![screen shot 2017-09-16 at 5 17 28 pm](https://user-images.githubusercontent.com/3578908/30516973-a624a30a-9b03-11e7-967d-3b161d2fbb9f.png)
